### PR TITLE
fix for error with matrix input (also issue #19)

### DIFF
--- a/R/nnSVG.R
+++ b/R/nnSVG.R
@@ -223,7 +223,7 @@ nnSVG <- function(input, spatial_coords = NULL, X = NULL,
   }
   
   if (is.null(BPPARAM)) {
-    BPPARAM <- MulticoreParam(workers = n_threads)
+    BPPARAM <- BiocParallel::MulticoreParam(workers = n_threads)
   }
   
   # -----------------------

--- a/R/nnSVG.R
+++ b/R/nnSVG.R
@@ -223,7 +223,7 @@ nnSVG <- function(input, spatial_coords = NULL, X = NULL,
   }
   
   if (is.null(BPPARAM)) {
-    BPPARAM <- BiocParallel::MulticoreParam(workers = n_threads)
+    BPPARAM <- MulticoreParam(workers = n_threads)
   }
   
   # -----------------------

--- a/R/nnSVG.R
+++ b/R/nnSVG.R
@@ -279,23 +279,25 @@ nnSVG <- function(input, spatial_coords = NULL, X = NULL,
   # calculate statistics
   # --------------------
   
-  if (is(input, "SpatialExperiment") & ("logcounts" %in% assayNames(spe))) {
-    lc <- logcounts(spe)
-    # mean logcounts
-    mat_brisc <- cbind(
-      mat_brisc, 
-      mean = rowMeans(lc)
-    )
-    # variance of logcounts
-    mat_brisc <- cbind(
-      mat_brisc, 
-      var = rowVars(as.matrix(lc))
-    )
-    # spatial coefficient of variation
-    mat_brisc <- cbind(
-      mat_brisc, 
-      spcov = sqrt(mat_brisc[, "sigma.sq"]) / mat_brisc[, "mean"]
-    )
+  if (is(input, "SpatialExperiment")) {
+    if ("logcounts" %in% assayNames(spe)) {
+      lc <- logcounts(spe)
+      # mean logcounts
+      mat_brisc <- cbind(
+        mat_brisc, 
+        mean = rowMeans(lc)
+      )
+      # variance of logcounts
+      mat_brisc <- cbind(
+        mat_brisc, 
+        var = rowVars(as.matrix(lc))
+      )
+      # spatial coefficient of variation
+      mat_brisc <- cbind(
+        mat_brisc, 
+        spcov = sqrt(mat_brisc[, "sigma.sq"]) / mat_brisc[, "mean"]
+      )
+    }
   } else {
     # return NAs if logcounts not provided
     mat_brisc <- cbind(


### PR DESCRIPTION
Testing if logcounts in assayNames (line 282) throws error if input is not SpatialExperiment. Separated ifs in line 282 to test if SpatialExperiment before it tests if logcounts in assayNames. 